### PR TITLE
[bug] Fix setting custom tip in Tip component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -32,7 +32,7 @@ export default function App() {
           <br />
           <br />
           <AddItem addItem={addItem} />
-          <Tip amount={total} setTipAmount={setTip} />
+          <Tip total={total} setTip={setTip} />
           <Text>Tip: {tip}</Text>
         </>
         <Text>Total: {total}</Text>

--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ export default function App() {
           <br />
           <AddItem addItem={addItem} />
           <Tip amount={total} setTipAmount={setTip} />
+          <Text>Tip: {tip}</Text>
         </>
         <Text>Total: {total}</Text>
       </>

--- a/src/components/Tip.js
+++ b/src/components/Tip.js
@@ -9,16 +9,16 @@ export default function Tip({
   const [tipPercentage, setTipPercentage] = useState(0)
   const [useCustomTip, setUseCustomTip] = useState(false)
 
-  const isTipValid = (tipPerecentageInput) => {
-    const numTip = parseInt(tipPerecentageInput);
+  const isTipValid = (tipPercentageInput) => {
+    const numTip = parseInt(tipPercentageInput);
     return (numTip >= 0) && (numTip < 100);
   }
 
-  const changePercentage = (total, tipPerecentageInput, isCustomPercentage) => {
-    const tipPerecentageFloat = parseFloat(tipPerecentageInput);
-    const tipAmount = parseFloat(total*tipPerecentageFloat/100).toFixed(2);
+  const changePercentage = (total, tipPercentageInput, isCustomPercentage) => {
+    const tipPercentageFloat = parseFloat(tipPercentageInput);
+    const tipAmount = parseFloat(total*tipPercentageFloat/100).toFixed(2);
 
-    setTipPercentage(parseInt(tipPerecentageFloat));
+    setTipPercentage(parseInt(tipPercentageFloat));
     setTip(tipAmount);
 
     !isCustomPercentage && setUseCustomTip(false)
@@ -61,9 +61,9 @@ export default function Tip({
                 Enter percentage here: 
             </Text>
             <TextInput
-              onChangeText={(tipPerecentageInput) => {
-                if (isTipValid(tipPerecentageInput)) {
-                  changePercentage(total, tipPerecentageInput, true)
+              onChangeText={(tipPercentageInput) => {
+                if (isTipValid(tipPercentageInput)) {
+                  changePercentage(total, tipPercentageInput, true)
                 }
               }}
               defaultValue={tipPercentage.toString()}
@@ -77,8 +77,8 @@ export default function Tip({
 }
 
 Tip.propTypes = {
-  amount: PropTypes.number.isRequired,
-  setTipAmount: PropTypes.func.isRequired,
+  total: PropTypes.number.isRequired,
+  setTip: PropTypes.func.isRequired,
 };
 
 const styles = StyleSheet.create({

--- a/src/components/Tip.js
+++ b/src/components/Tip.js
@@ -2,23 +2,27 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Text, View, Button, TextInput } from 'react-native';
 
-export default function Tip({ amount, setTipAmount }) {
-  const [tipPercentage, setTipPercentage] = useState(0);
-  const [useCustomTip, setUseCustomTip] = useState(false);
+export default function Tip({
+  total,
+  setTip
+}) {
+  const [tipPercentage, setTipPercentage] = useState(0)
+  const [useCustomTip, setUseCustomTip] = useState(false)
 
-  const isTipValid = (tipAmount) => {
-    const numAmount = parseInt(tipAmount);
-    return numAmount >= 0 && numAmount < 100;
-  };
+  const isTipValid = (tipPerecentageInput) => {
+    const numTip = parseInt(tipPerecentageInput);
+    return (numTip >= 0) && (numTip < 100);
+  }
 
-  const changePercentage = (amount, tipPercentage, isCustomPercentage) => {
-    const tipAmount = ((amount * tipPercentage) / 100).toFixed(2);
-    setTipPercentage(tipPercentage);
-    setTipAmount(tipAmount);
-    if (!isCustomPercentage) {
-      setUseCustomTip(false);
-    }
-  };
+  const changePercentage = (total, tipPerecentageInput, isCustomPercentage) => {
+    const tipPerecentageFloat = parseFloat(tipPerecentageInput);
+    const tipAmount = parseFloat(total*tipPerecentageFloat/100).toFixed(2);
+
+    setTipPercentage(parseInt(tipPerecentageFloat));
+    setTip(tipAmount);
+
+    !isCustomPercentage && setUseCustomTip(false)
+  }
 
   const validTipPercentages = [15, 18, 20];
 
@@ -26,26 +30,24 @@ export default function Tip({ amount, setTipAmount }) {
 
   return (
     <>
-      <View class="tip-header">
-        <Text>Tip Amount: ${((amount * tipPercentage) / 100).toFixed(2)}</Text>
-      </View>
-      <View class="tip-options" style={styles.row}>
-        {Object.entries(validTipPercentages).map(([index, validTipPercentage]) => {
-          const validTipPercentageString = getValidPercentageString(validTipPercentage);
-          return (
-            <Button
-              key={index}
-              class="tip-percentage"
-              title={validTipPercentageString}
-              onPress={() => {
-                if (isTipValid(validTipPercentage)) {
-                  changePercentage(amount, validTipPercentage, false);
-                }
-              }}
-            />
-          );
-        })}
-
+      <View class='tip-options' style={styles.row}>
+        {
+          validTipPercentages.map((validTipPercentage, index) => {
+            const validTipPercentageString = getValidPercentageString(validTipPercentage);
+            return(
+              <Button
+                key={index}
+                class='tip-percentage'
+                title={validTipPercentageString}
+                onPress={() => {
+                  if (isTipValid(validTipPercentage)) {
+                    changePercentage(total, validTipPercentage, false)
+                  }
+                }}
+              />
+            )
+          })
+        }
         <Button
           key={validTipPercentages.length}
           class="tip-percentage"
@@ -54,20 +56,20 @@ export default function Tip({ amount, setTipAmount }) {
         />
       </View>
       {useCustomTip && (
-        <View class="custom-tip-percentage">
-          <Text>Enter percentage here:</Text>
-          <TextInput
-            onChangeText={(value) => {
-              const tipPercentage = parseInt(value);
-              if (isTipValid(tipPercentage)) {
-                changePercentage(amount, tipPercentage, true);
-              }
-            }}
-            value={tipPercentage.toFixed(2)}
-            maxLength={2}
-            keyboardType="numeric"
-          />
-          <Text>%</Text>
+        <View class='custom-tip-percentage'>
+            <Text>
+                Enter percentage here: 
+            </Text>
+            <TextInput
+              onChangeText={(tipPerecentageInput) => {
+                if (isTipValid(tipPerecentageInput)) {
+                  changePercentage(total, tipPerecentageInput, true)
+                }
+              }}
+              defaultValue={tipPercentage.toString()}
+              maxLength={2}
+              keyboardType="numeric"
+            />
         </View>
       )}
     </>

--- a/src/tests/components/Tip.test.js
+++ b/src/tests/components/Tip.test.js
@@ -3,40 +3,41 @@ import { shallow } from 'enzyme';
 import { Button, View, Text, TextInput } from 'react-native';
 import Tip from '../../components/Tip';
 
-const mockSetTipAmount = jest.fn();
+const mockSetTip = jest.fn();
 
 describe('Tip component', () => {
   let wrapper;
-  const amount = 15;
+  const total = 15;
 
   beforeEach(() => {
-    wrapper = shallow(<Tip amount={amount} setTipAmount={mockSetTipAmount} />);
+    wrapper = shallow(<Tip total={total} setTip={mockSetTip}/>);
   });
-
+  
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  const calculateTip = (perecentage) => (perecentage * amount).toFixed(2);
+  const calculateTip = (perecentage) => {
+    return (perecentage * total).toFixed(2)
+  };
 
   const setUpCustomTestScenarios = () => {
-    const tipOptions = wrapper.find(View).at(1);
+    const tipOptions = wrapper.find(View).at(0);
     const selectCustomTip = tipOptions.find(Button).at(3);
 
     selectCustomTip.simulate('press');
-  };
+  }
 
   it('has four tip buttons', () => {
     expect(wrapper.find(Button)).toHaveLength(4);
   });
 
   it('valid tip is not calculated when no percentage or amount is selected', () => {
-    const tipHeaderText = wrapper.find(Text).at(0).shallow().text();
-    expect(tipHeaderText.includes('$0.00')).toBe(true);
+    expect(mockSetTip).not.toHaveBeenCalled();
   });
 
   it('valid tip is calculated when selecting 15%', () => {
-    const tipOptions = wrapper.find(View).at(1);
+    const tipOptions = wrapper.find(View).at(0);
     const fifteenPercentTip = tipOptions.find(Button).at(0);
     const expectedTip = calculateTip(0.15);
 
@@ -44,67 +45,64 @@ describe('Tip component', () => {
 
     wrapper.update();
 
-    const tipHeaderText = wrapper.find(Text).at(0).shallow().text();
-    expect(tipHeaderText.includes(expectedTip)).toBe(true);
-    expect(mockSetTipAmount).toHaveBeenCalledWith('2.25');
+    expect(mockSetTip).toHaveBeenCalledWith("2.25");
   });
 
   it('valid custom tip is enabled when selecting custom tip', () => {
-    const tipOptions = wrapper.find(View).at(1);
+    const tipOptions = wrapper.find(View).at(0);
     const selectCustomTip = tipOptions.find(Button).at(3);
 
-    expect(wrapper.find(View)).toHaveLength(2);
+    expect(wrapper.find(View)).toHaveLength(1);
     selectCustomTip.simulate('press');
-    expect(wrapper.find(View)).toHaveLength(3);
+    expect(wrapper.find(View)).toHaveLength(2);
   });
 
   it('valid custom tip is calculated when entering tip percentage', () => {
     setUpCustomTestScenarios();
-    const customTip = wrapper.find(View).at(2);
+
+    const customTip = wrapper.find(View).at(1);
     const customTipTextInput = customTip.find(TextInput).at(0).shallow();
 
     customTipTextInput.simulate('changeText', '12');
     const expectedTip = calculateTip(0.12);
 
-    expect(mockSetTipAmount).toHaveBeenCalledWith(expectedTip);
+    expect(mockSetTip).toHaveBeenCalledWith(expectedTip);
   });
 
   it('invalid custom tip is not calculated when entering a tip percentage larger than 100', () => {
     setUpCustomTestScenarios();
 
-    const customTip = wrapper.find(View).at(2);
+    const customTip = wrapper.find(View).at(1);
     const customTipTextInput = customTip.find(TextInput).at(0).shallow();
+
     customTipTextInput.simulate('changeText', '344');
 
-    expect(mockSetTipAmount).not.toHaveBeenCalled();
+    expect(mockSetTip).not.toHaveBeenCalled();
   });
 
   it('invalid custom tip is not calculated when entering a non numeric tip percentage', () => {
     setUpCustomTestScenarios();
 
-    const customTip = wrapper.find(View).at(2);
+    const customTip = wrapper.find(View).at(1);
     const customTipTextInput = customTip.find(TextInput).at(0).shallow();
+
     customTipTextInput.simulate('changeText', '@#!@#dfwerc');
 
-    expect(mockSetTipAmount).not.toHaveBeenCalled();
+    expect(mockSetTip).not.toHaveBeenCalled();
   });
 
   it('valid custom tip remains after invalid tip was entered', () => {
-    const tipOptions = wrapper.find(View).at(1);
-    const selectCustomTip = tipOptions.find(Button).at(3);
+    setUpCustomTestScenarios();
 
-    selectCustomTip.simulate('press');
-
-    const customTip = wrapper.find(View).at(2);
+    const customTip = wrapper.find(View).at(1);
     const customTipTextInput = customTip.find(TextInput).at(0).shallow();
 
     customTipTextInput.simulate('changeText', '12');
-
-    const originalTipAmount = wrapper.find(Text).at(0).shallow().text();
+    const expectedTip = calculateTip(0.12);
 
     customTipTextInput.simulate('changeText', 'dfwerc');
 
-    const currentTipAmount = wrapper.find(Text).at(0).shallow().text();
-    expect(currentTipAmount).toEqual(originalTipAmount);
+    expect(mockSetTip).toHaveBeenNthCalledWith(1, expectedTip);
+    expect(mockSetTip).not.toHaveBeenNthCalledWith(2);
   });
 });

--- a/src/tests/pages/App.test.js
+++ b/src/tests/pages/App.test.js
@@ -1,16 +1,15 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import App from '../../App';
 import AddItem from '../../components/AddItem';
 import Tip from '../../components/Tip';
 
-describe('App page', () => {
-  let wrapper;
 
+describe('App page', () => {
   beforeEach(() => {
     wrapper = shallow(<App />);
   });
-
+  
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -18,5 +17,5 @@ describe('App page', () => {
   it('loads all the expected components', () => {
     expect(wrapper.find(AddItem)).toHaveLength(1);
     expect(wrapper.find(Tip)).toHaveLength(1);
-  });
-});
+  })
+})


### PR DESCRIPTION
## Description
**Note:** This is a redo of [my other branch](https://github.com/tally-team/tally-frontend/pull/14) which got messed up, lol.

This PR serves to fix some changes in `<App />` component as well as the `<Tip/>` component. 

The current bug with `<Tip/>` component is when user tries to enter a custom tip, the field keeps getting reset. Additionally the tipAmount fails to update.

This is due to the value prop on `<Tip/>` component being set to the tipPercentage state, which is a float, not a String. Additionally, according to the official React Native doc, we should be using the defaultValue prop for the `<TextInput/>` component.

The changes are as follows:
1. Wrapping text with `<Tex/>` as warnings pop up about them: `Error: Text strings must be rendered within a `<Text>` component.`
2. Changing `value` to `defaultValue` prop for the text input component in `<Tip/>` as the value of TextInput was not updating properly. See [StackOverflow answer](https://stackoverflow.com/a/64235282) and [official React Native doc where defaultValue is being used](https://reactnative.dev/docs/handling-text-input).

## How Has This Been Tested?
* Updated passing unit tests to account for the changes
* Tested the UI component: [Video walkthrough of component before the fix](https://user-images.githubusercontent.com/14842270/159400390-1b642202-5128-4670-9b30-c4f544db17ee.mov) vs [video walkthrough of component after the fix](https://user-images.githubusercontent.com/14842270/159395348-fd2c4835-0bbe-4268-a392-df8c8a1e8a59.mov)
