### PR TITLE
[Task-9] Refactor FE management state to use `useReducer` 

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-native/extend-expect';

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
     ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  setupFilesAfterEnv: ['./jest-setup.ts'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.12.9",
+        "@testing-library/jest-native": "^5.4.2",
         "@testing-library/react-native": "^12.1.2",
         "@types/jest": "^29.0.0",
         "@types/react": "~18.0.14",
@@ -4026,11 +4027,11 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5668,9 +5669,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.0",
@@ -5686,6 +5687,126 @@
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.2.tgz",
+      "integrity": "sha512-Vo/CE1uvCVH1H8YPoOEXLXVsm+BjzSQTq35+wkri1fr0O5D+A2WZ+m3ni5g6f1OCzNKNGIAHmisBEWkDs1P1mw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-native/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/pretty-format": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-native/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-native/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@testing-library/react-native": {
@@ -17259,6 +17380,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.7.6",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
@@ -19525,6 +19655,19 @@
         "node": ">= 4"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -20931,6 +21074,18 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -25648,11 +25803,11 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
       "requires": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       }
     },
     "@jest/source-map": {
@@ -26885,9 +27040,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "@sinonjs/commons": {
       "version": "3.0.0",
@@ -26903,6 +27058,95 @@
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "requires": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "@testing-library/jest-native": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.2.tgz",
+      "integrity": "sha512-Vo/CE1uvCVH1H8YPoOEXLXVsm+BjzSQTq35+wkri1fr0O5D+A2WZ+m3ni5g6f1OCzNKNGIAHmisBEWkDs1P1mw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "29.6.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.6.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@testing-library/react-native": {
@@ -35604,6 +35848,12 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "mini-css-extract-plugin": {
       "version": "2.7.6",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
@@ -37213,6 +37463,16 @@
         "tslib": "^2.0.1"
       }
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -38322,6 +38582,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
+    "@expo/webpack-config": "^18.0.1",
     "expo": "~48.0.18",
     "expo-status-bar": "~1.4.4",
     "prop-types": "^15.8.1",
@@ -22,11 +23,11 @@
     "react-native-web": "~0.18.10",
     "source-map-loader": "^3.0.1",
     "ts-jest": "^29.0.0",
-    "typescript": "^4.9.4",
-    "@expo/webpack-config": "^18.0.1"
+    "typescript": "^4.9.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
+    "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react-native": "^12.1.2",
     "@types/jest": "^29.0.0",
     "@types/react": "~18.0.14",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,119 @@
-import React, { useState } from 'react';
+import React, { useReducer } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import AddItem from './components/AddItem';
 import AddPartyMember from './components/AddPartyMember';
 import Tax from './components/Tax';
 import Tip from './components/Tip';
 
-export default function App() {
-  const [total, setTotal] = useState(0);
-  const [items, setItems] = useState({});
-  const [party, setParty] = useState([]);
-  const [tip, setTip] = useState(0);
-  const [tax, setTax] = useState(0);
+enum Actions {
+  ADD_ITEM = 'add_item',
+  ADD_PARTY_MEMBER = 'add_party_member',
+  SET_TIP = 'set_tip',
+  SET_TAX = 'set_tax',
+}
 
-  const addItem = (itemName: string, itemPrice: number, itemPurchaserList: Array<string>) => {
-    setItems({ ...items, [itemName]: [itemPrice, itemPurchaserList] });
-    setTotal(Number((total + itemPrice).toFixed(2)));
+type AppStateType = {
+  total: number;
+  items: {
+    [name: string]: {
+      price: number;
+      purchaserList: string[];
+    };
+  };
+  party: string[];
+  tip: number;
+  tax: number;
+};
+
+type ActionArgs = {
+  type: Actions;
+
+  // item name or party member name
+  name: string;
+
+  // item details
+  price: number;
+  purchaserList: string[];
+
+  // tax or tip amount
+  amount: number;
+};
+
+export default function App() {
+  const initialState: AppStateType = {
+    total: 0,
+    items: {},
+    party: [],
+    tip: 0,
+    tax: 0,
   };
 
-  const addPartyMember = (memberName: string) => {
-    setParty([...party, memberName]);
+  const reducer = (state: AppStateType, action: Partial<ActionArgs>) => {
+    switch (action.type) {
+      case Actions.ADD_ITEM: {
+        return {
+          ...state,
+          items: {
+            ...state.items,
+            [action.name]: {
+              price: action.price,
+              purchaserList: action.purchaserList,
+            },
+          },
+          total: Number((state.total + action.price).toFixed(2)),
+        };
+      }
+      case Actions.ADD_PARTY_MEMBER: {
+        return {
+          ...state,
+          party: [...state.party, action.name],
+        };
+      }
+      case Actions.SET_TIP: {
+        return {
+          ...state,
+          tip: action.amount,
+        };
+      }
+      case Actions.SET_TAX: {
+        return {
+          ...state,
+          tax: action.amount,
+        };
+      }
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const addItem = (name: string, price: number, purchaserList: Array<string>) => {
+    dispatch({
+      type: Actions.ADD_ITEM,
+      name: name,
+      price: price,
+      purchaserList: purchaserList,
+    });
+  };
+
+  const addPartyMember = (name: string) => {
+    dispatch({
+      type: Actions.ADD_PARTY_MEMBER,
+      name: name,
+    });
+  };
+
+  const setTip = (amount: number) => {
+    dispatch({
+      type: Actions.SET_TIP,
+      amount: amount,
+    });
+  };
+
+  const setTax = (amount: number) => {
+    dispatch({
+      type: Actions.SET_TAX,
+      amount: amount,
+    });
   };
 
   return (
@@ -27,7 +122,7 @@ export default function App() {
         <>
           <Text>Party</Text>
 
-          {party.map((name, index) => (
+          {state.party.map((name, index) => (
             <Text key={`${name}-${index}`}>{name}</Text>
           ))}
           <Text>
@@ -40,12 +135,12 @@ export default function App() {
             {`\n`}
           </Text>
           <Text>Item List</Text>
-          {Object.keys(items).map((itemName) => {
-            const [itemPrice, purchaserList] = [...items[itemName]];
+          {Object.keys(state.items).map((itemName) => {
+            const { price, purchaserList } = state.items[itemName];
             return (
               <View style={styles.row} key={itemName}>
                 <Text>
-                  {itemName}: {itemPrice}
+                  {itemName}: {price}
                 </Text>
                 <Text>Purchasers: {purchaserList.join(', ')}</Text>
               </View>
@@ -55,13 +150,13 @@ export default function App() {
             {`\n`}
             {`\n`}
           </Text>
-          <AddItem addItem={addItem} party={party} />
-          <Tax tax={tax} setTax={setTax} />
-          <Text>Tax: {tax.toFixed(2)}</Text>
-          <Tip total={total} setTip={setTip} />
-          <Text>Tip: {tip.toFixed(2)}</Text>
+          <AddItem addItem={addItem} party={state.party} />
+          <Tax tax={state.tax} setTax={setTax} />
+          <Text>Tax: {state.tax.toFixed(2)}</Text>
+          <Tip total={state.total} setTip={setTip} />
+          <Text>Tip: {state.tip.toFixed(2)}</Text>
         </>
-        <Text>Subtotal: {total}</Text>
+        <Text>Subtotal: {state.total}</Text>
       </>
     </View>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,18 +25,31 @@ type AppStateType = {
   tax: number;
 };
 
+type PartyMemberDetailsType = {
+  name: string;
+};
+
+type ItemDetailsType = {
+  name: string;
+  price: number;
+  purchaserList: string[];
+};
+
+type TaxDetailsType = {
+  amount: number;
+};
+
+type TipDetails = {
+  amount: number;
+};
+
 type ActionArgs = {
   type: Actions;
 
-  // item name or party member name
-  name: string;
-
-  // item details
-  price: number;
-  purchaserList: string[];
-
-  // tax or tip amount
-  amount: number;
+  partyMemberDetails: PartyMemberDetailsType;
+  itemDetails: ItemDetailsType;
+  taxDetails: TaxDetailsType;
+  tipDetails: TipDetails;
 };
 
 export default function App() {
@@ -51,11 +64,12 @@ export default function App() {
   const reducer = (state: AppStateType, action: Partial<ActionArgs>) => {
     switch (action.type) {
       case Actions.ADD_ITEM: {
+        const { name, price, purchaserList } = action.itemDetails;
         const updatedItems = {
           ...state.items,
-          [action.name]: {
-            price: action.price,
-            purchaserList: action.purchaserList,
+          [name]: {
+            price: price,
+            purchaserList: purchaserList,
           },
         };
         const total = Object.values(updatedItems).reduce(
@@ -70,21 +84,24 @@ export default function App() {
         };
       }
       case Actions.ADD_PARTY_MEMBER: {
+        const { name } = action.partyMemberDetails;
         return {
           ...state,
-          party: [...state.party, action.name],
+          party: [...state.party, name],
         };
       }
       case Actions.SET_TIP: {
+        const { amount } = action.tipDetails;
         return {
           ...state,
-          tip: action.amount,
+          tip: amount,
         };
       }
       case Actions.SET_TAX: {
+        const { amount } = action.taxDetails;
         return {
           ...state,
-          tax: action.amount,
+          tax: amount,
         };
       }
     }
@@ -95,30 +112,38 @@ export default function App() {
   const addItem = (name: string, price: number, purchaserList: Array<string>) => {
     dispatch({
       type: Actions.ADD_ITEM,
-      name: name,
-      price: price,
-      purchaserList: purchaserList,
+      itemDetails: {
+        name: name,
+        price: price,
+        purchaserList: purchaserList,
+      },
     });
   };
 
   const addPartyMember = (name: string) => {
     dispatch({
       type: Actions.ADD_PARTY_MEMBER,
-      name: name,
+      partyMemberDetails: {
+        name: name,
+      },
     });
   };
 
   const setTip = (amount: number) => {
     dispatch({
       type: Actions.SET_TIP,
-      amount: amount,
+      tipDetails: {
+        amount: amount,
+      },
     });
   };
 
   const setTax = (amount: number) => {
     dispatch({
       type: Actions.SET_TAX,
-      amount: amount,
+      taxDetails: {
+        amount: amount,
+      },
     });
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,16 +51,22 @@ export default function App() {
   const reducer = (state: AppStateType, action: Partial<ActionArgs>) => {
     switch (action.type) {
       case Actions.ADD_ITEM: {
+        const updatedItems = {
+          ...state.items,
+          [action.name]: {
+            price: action.price,
+            purchaserList: action.purchaserList,
+          },
+        };
+        const total = Object.values(updatedItems).reduce(
+          (sum, itemDetail) => sum + itemDetail.price,
+          0
+        );
+
         return {
           ...state,
-          items: {
-            ...state.items,
-            [action.name]: {
-              price: action.price,
-              purchaserList: action.purchaserList,
-            },
-          },
-          total: Number((state.total + action.price).toFixed(2)),
+          items: updatedItems,
+          total: total,
         };
       }
       case Actions.ADD_PARTY_MEMBER: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,6 @@ type TipDetails = {
 
 type ActionArgs = {
   type: Actions;
-
   partyMemberDetails: PartyMemberDetailsType;
   itemDetails: ItemDetailsType;
   taxDetails: TaxDetailsType;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ enum Actions {
   SET_TAX = 'set_tax',
 }
 
-type AppStateType = {
+type AppState = {
   total: number;
   items: {
     [name: string]: {
@@ -25,17 +25,17 @@ type AppStateType = {
   tax: number;
 };
 
-type PartyMemberDetailsType = {
+type PartyMemberDetails = {
   name: string;
 };
 
-type ItemDetailsType = {
+type ItemDetails = {
   name: string;
   price: number;
   purchaserList: string[];
 };
 
-type TaxDetailsType = {
+type TaxDetails = {
   amount: number;
 };
 
@@ -45,14 +45,14 @@ type TipDetails = {
 
 type ActionArgs = {
   type: Actions;
-  partyMemberDetails: PartyMemberDetailsType;
-  itemDetails: ItemDetailsType;
-  taxDetails: TaxDetailsType;
+  partyMemberDetails: PartyMemberDetails;
+  itemDetails: ItemDetails;
+  taxDetails: TaxDetails;
   tipDetails: TipDetails;
 };
 
 export default function App() {
-  const initialState: AppStateType = {
+  const initialState: AppState = {
     total: 0,
     items: {},
     party: [],
@@ -60,7 +60,7 @@ export default function App() {
     tax: 0,
   };
 
-  const reducer = (state: AppStateType, action: Partial<ActionArgs>) => {
+  const reducer = (state: AppState, action: Partial<ActionArgs>) => {
     switch (action.type) {
       case Actions.ADD_ITEM: {
         const { name, price, purchaserList } = action.itemDetails;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ export default function App() {
         return {
           ...state,
           items: updatedItems,
-          total: total,
+          total: Number(total.toFixed(2)),
         };
       }
       case Actions.ADD_PARTY_MEMBER: {

--- a/src/tests/pages/App.test.tsx
+++ b/src/tests/pages/App.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import App from '../../App';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent, within } from '@testing-library/react-native';
+import { FlatList } from 'react-native';
+import '@testing-library/jest-native';
 
 describe('App page', () => {
   let wrapper;
@@ -13,14 +15,69 @@ describe('App page', () => {
     jest.clearAllMocks();
   });
 
+  const setUpParty = () => {
+    const partyMemberNameInput = wrapper.getByPlaceholderText('Name');
+    const addPartyMemberButton = wrapper.getByText('Add Party Member');
+
+    fireEvent.changeText(partyMemberNameInput, 'Person A');
+    fireEvent.press(addPartyMemberButton);
+
+    fireEvent.changeText(partyMemberNameInput, 'Person B');
+    fireEvent.press(addPartyMemberButton);
+  };
+
+  const setUpItems = (itemsList) => {
+    const itemNameInput = wrapper.getByPlaceholderText('Item Name');
+    const priceInput = wrapper.getByPlaceholderText('0.00');
+    const addItemButton = wrapper.getByText('Add Item');
+    const partyMemberList = wrapper.root.findByType(FlatList);
+
+    itemsList.forEach((itemDetails) => {
+      const [name, price, purchaserList] = itemDetails;
+
+      fireEvent.changeText(priceInput, price);
+      fireEvent.changeText(itemNameInput, name);
+
+      purchaserList.forEach((purchaser) => {
+        const partyMember = within(partyMemberList).getByText(purchaser);
+        fireEvent.press(partyMember);
+      });
+
+      fireEvent.press(addItemButton);
+    });
+  };
+
   it('loads all the expected components', () => {
     // adding party member shows
-    expect(wrapper.queryByText('Add Party Member')).not.toBeNull();
+    expect(wrapper.queryByText('Add Party Member')).toBeOnTheScreen();
 
     // adding party item shows
-    expect(wrapper.queryByText('Add Item')).not.toBeNull();
+    expect(wrapper.queryByText('Add Item')).toBeOnTheScreen();
 
     // tip section shows
-    expect(wrapper.queryByText('15%')).not.toBeNull();
+    expect(wrapper.queryByText('15%')).toBeOnTheScreen();
+  });
+
+  it('shows correct subtotal', () => {
+    setUpParty();
+
+    const itemsList = [
+      ['pokeball', '20.50', ['Person A']],
+      ['riceball', '13.24', ['Person B']],
+    ];
+    setUpItems(itemsList);
+    expect(wrapper.getByText(/Subtotal/)).toHaveTextContent('33.74');
+  });
+
+  it('shows correct subtotal after repricing an item', () => {
+    setUpParty();
+
+    const itemsList = [
+      ['pokeball', '20.50', ['Person A']],
+      ['riceball', '13.24', ['Person B']],
+      ['pokeball', '21.53', ['Person A']],
+    ];
+    setUpItems(itemsList);
+    expect(wrapper.queryByText(/Subtotal/)).toHaveTextContent('34.77');
   });
 });


### PR DESCRIPTION
[[Task-9](https://github.com/tally-team/tally-frontend/issues/9)] Refactor FE management state to use `useReducer`

## Description

This PR handles refactoring the FE management state to use `useReducer` in `App.tsx`, where we have state management details for the following and followed the documentation [here](https://react.dev/reference/react/useReducer):
* Party members
* Items
* Tip
* Tax

This PR also resolves a current bug where if a user overwrites the details of an existing item, the subtotal is inaccurate since we continuously increment it assuming the user will add a new item each time. Tests have been written to check for subtotal changes.

As part of the test changes, the `@testing-library/jest-native` library is also added for extra expect methods. Followed the documentation here for installing and configuring: https://github.com/testing-library/jest-native

## How Has This Been Tested?

Tested locally + wrote tests for checking subtotal

https://github.com/tally-team/tally-frontend/assets/24977851/5d9c4586-ade4-4f3c-9c1d-26669f285499

