### PR TITLE
[Task-27] Set up API call to fetch users Part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ react native front end app for tally application
   - Make sure you have an emulator running (Android Studio > AVD > Select play on a device)
 - `npm run ios`: start ios app
 - `npm run web`: start web app
+
+## local dev with server
+
+To run with the server, make sure you have tally-backend setup and running (`npm run start-dev`). The server needs to run 
+prior to making API calls.

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ react native front end app for tally application
 
 ## local dev with server
 
-To run with the server, make sure you have tally-backend setup and running (`npm run start-dev`). The server needs to run 
+To run with the server, make sure you have tally-backend setup and running (`npm run start-dev`). The server needs to be up and running 
 prior to making API calls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@babel/preset-typescript": "^7.16.7",
         "@expo/webpack-config": "^18.0.1",
+        "axios": "^1.4.0",
         "expo": "~48.0.18",
         "expo-status-bar": "~1.4.4",
         "prop-types": "^15.8.1",
@@ -6522,6 +6523,29 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -17820,6 +17844,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,5 @@
       "react-app/jest"
     ]
   },
-  "private": true,
-  "proxy": "http://localhost:8000"
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@expo/webpack-config": "^18.0.1",
+    "axios": "^1.4.0",
     "expo": "~48.0.18",
     "expo-status-bar": "~1.4.4",
     "prop-types": "^15.8.1",
@@ -56,5 +57,6 @@
       "react-app/jest"
     ]
   },
-  "private": true
+  "private": true,
+  "proxy": "http://localhost:8000"
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+const getUsers = async () => {
+  const { data } = await axios.get('http://localhost:8080/api/users')
+  return data;
+}
+
+export default {
+  getUsers
+}


### PR DESCRIPTION
## [Task-27] Set up API call to fetch users

This PR handles setting up an api file where we can store methods to hit the endpoints in tally-backend. Currently only GET users endpoint is added. 

## How Has This Been Tested?

Tested with the backend changes made in this PR: https://github.com/tally-team/tally-backend/pull/65 + made a call to get the users endpoint somewhere in `App` (removed the code since it was for testing purposes)

<img width="635" alt="Screen Shot 2023-08-08 at 10 06 39 AM" src="https://github.com/tally-team/tally-frontend/assets/24977851/0114fbfb-c858-4b8c-ae53-71137fbe0922">
